### PR TITLE
feat: อัปเกรด `actions/upload-artifact` เป็น v4

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
         run: npm run build
 
       - name: Upload production artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build
           path: dist


### PR DESCRIPTION
อัปเกรด `actions/upload-artifact` จาก v3 เป็น v4 เพื่อปรับปรุงประสิทธิภาพและความเสถียรของ GitHub Actions workflow ตามแนวทางปฏิบัติล่าสุด