### PR TITLE
feat: อัปเกรด `actions/upload-artifact` เป็น v4 และเพิ่มขั้นตอน Deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js
@@ -21,7 +23,13 @@ jobs:
         run: npm run build
 
       - name: Upload production artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build
           path: dist
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist


### PR DESCRIPTION
- อัปเกรด `actions/upload-artifact` จาก v3 เป็น v4 เพื่อปรับปรุงประสิทธิภาพและความเสถียร
- เพิ่มขั้นตอนการ Deploy ไปยัง GitHub Pages โดยใช้ `peaceiris/actions-gh-pages`
- เพิ่ม permission `contents: write` เพื่อให้ workflow สามารถ push ไปยัง branch `gh-pages` ได้