### PR TITLE
Fix: Attempt to resolve Vite timeout issue

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,16 +7,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"],
-      "@/components/*": ["./src/components/*"],
-      "@/app/*": ["./src/app/*"],
-      "@/pages/*": ["./src/app/pages/*"],
-      "@/shared/*": ["./src/shared/*"],
-      "@/hooks/*": ["./src/shared/hooks/*"],
-      "@/utils/*": ["./src/shared/utils/*"],
-      "@/assets/*": ["./src/shared/assets/*"],
-      "@/lib/*": ["./src/shared/lib/*"],
-      "@/types/*": ["./src/types/*"]
+      "@/*": ["./src/*"]
     },
     "noImplicitAny": false,
     "noUnusedParameters": false,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,15 +26,6 @@ export default defineConfig(({ mode }) => {
     resolve: {
       alias: {
         "@": path.resolve(__dirname, "./src"),
-        "@/components": path.resolve(__dirname, "./src/components"),
-        "@/app": path.resolve(__dirname, "./src/app"),
-        "@/pages": path.resolve(__dirname, "./src/app/pages"),
-        "@/shared": path.resolve(__dirname, "./src/shared"),
-        "@/hooks": path.resolve(__dirname, "./src/shared/hooks"),
-        "@/utils": path.resolve(__dirname, "./src/shared/utils"),
-        "@/assets": path.resolve(__dirname, "./src/shared/assets"),
-        "@/lib": path.resolve(__dirname, "./src/shared/lib"),
-        "@/types": path.resolve(__dirname, "./src/types"),
       },
     },
   }


### PR DESCRIPTION
This commit attempts to resolve the timeout issue when running `npm run dev`.

The following changes were made:

- Simplified path aliases in `vite.config.ts` and `tsconfig.json` to prevent potential resolution loops.
- Removed a duplicate `Toaster` component import in `App.tsx` that may have caused conflicts.
- Added a `.npmrc` file with `legacy-peer-deps=true` to address potential dependency installation issues.

Despite these changes, the timeout issue persists, suggesting a more complex underlying problem possibly related to the development environment or a specific dependency.