### PR TITLE
fix: Correct build artifact path in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,10 +26,10 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: build
-          path: dist
+          path: build
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./dist
+          publish_dir: ./build


### PR DESCRIPTION
The Vite configuration specifies the build output directory as `build`, but the GitHub Actions workflow was incorrectly configured to use `dist`. This caused the deployment step to fail because it couldn't find the specified directory.

This commit updates the workflow file to use the correct `build` directory for both creating artifacts and deploying to GitHub Pages, ensuring the deployment process can complete successfully.