### PR TITLE
feat: Add global 'Create Post' button and modal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -98,7 +98,7 @@
         "vitest": "^3.2.4"
       },
       "engines": {
-        "node": "18.x"
+        "node": "22.x"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/src/app/pages/CommunityFeed.tsx
+++ b/src/app/pages/CommunityFeed.tsx
@@ -5,19 +5,18 @@ import { Badge } from '@/components/ui/badge';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import OptimizedImage from '@/components/common/OptimizedImage';
-import { 
-  PlusCircle, 
-  TrendingUp, 
-  Users, 
+import {
+  TrendingUp,
+  Users,
   Star,
   Filter,
   Search
 } from 'lucide-react';
 import { PostCard } from '@/components/community/PostCard';
-import { CreatePost } from '@/components/community/CreatePost';
 import { GroupCard } from '@/components/community/GroupCard';
 import { UserPoints } from '@/components/community/UserPoints';
 import { useCommunity } from '@/shared/hooks/useCommunity';
+import { useUIContext } from '@/shared/contexts/UIContext';
 import { FeedFilter } from '@/shared/types/community';
 import { Input } from '@/components/ui/input';
 
@@ -28,9 +27,9 @@ interface CommunityFeedProps {
 export const CommunityFeed: React.FC<CommunityFeedProps> = ({
   currentLanguage: _currentLanguage
 }) => {
-  const [showCreatePost, setShowCreatePost] = useState(false);
   const [activeTab, setActiveTab] = useState('feed');
   const [searchQuery, setSearchQuery] = useState('');
+  const { openCreatePostModal } = useUIContext();
 
   const {
     posts,
@@ -41,8 +40,6 @@ export const CommunityFeed: React.FC<CommunityFeedProps> = ({
     isLoadingGroups,
     userPoints,
     isLoadingPoints,
-    createPost,
-    isCreatingPost,
     likePost,
     savePost,
     sharePost,
@@ -55,8 +52,8 @@ export const CommunityFeed: React.FC<CommunityFeedProps> = ({
     setFeedFilter({ ...feedFilter, ...newFilter });
   };
 
-  const filteredPosts = posts.filter(post => 
-    searchQuery === '' || 
+  const filteredPosts = posts.filter(post =>
+    searchQuery === '' ||
     post.content.toLowerCase().includes(searchQuery.toLowerCase()) ||
     post.tags.some(tag => tag.toLowerCase().includes(searchQuery.toLowerCase())) ||
     post.location?.name.toLowerCase().includes(searchQuery.toLowerCase())
@@ -78,14 +75,6 @@ export const CommunityFeed: React.FC<CommunityFeedProps> = ({
             แบ่งปันเรื่องราวและประสบการณ์การเดินทางของคุณ
           </p>
         </div>
-        
-        <Button 
-          onClick={() => setShowCreatePost(true)}
-          className="flex items-center space-x-2"
-        >
-          <PlusCircle className="h-4 w-4" />
-          <span>สร้างโพสต์</span>
-        </Button>
       </div>
 
       {/* Search */}
@@ -130,9 +119,9 @@ export const CommunityFeed: React.FC<CommunityFeedProps> = ({
                     <div className="flex items-center space-x-3">
                       <Filter className="h-4 w-4 text-muted-foreground" />
                       <span className="text-sm font-medium">แสดง:</span>
-                      
-                      <Select 
-                        value={feedFilter.type} 
+
+                      <Select
+                        value={feedFilter.type}
                         onValueChange={(value: 'all' | 'following' | 'groups' | 'saved') => handleFilterChange({ type: value })}
                       >
                         <SelectTrigger className="w-auto">
@@ -147,8 +136,8 @@ export const CommunityFeed: React.FC<CommunityFeedProps> = ({
                       </Select>
                     </div>
 
-                    <Select 
-                      value={feedFilter.sortBy} 
+                    <Select
+                      value={feedFilter.sortBy}
                       onValueChange={(value: 'latest' | 'popular' | 'trending' | 'inspiration') => handleFilterChange({ sortBy: value })}
                     >
                       <SelectTrigger className="w-auto">
@@ -207,7 +196,7 @@ export const CommunityFeed: React.FC<CommunityFeedProps> = ({
                     <p className="text-sm text-muted-foreground mb-4">
                       {searchQuery ? 'ลองค้นหาด้วยคำอื่น' : 'เป็นคนแรกที่สร้างโพสต์!'}
                     </p>
-                    <Button onClick={() => setShowCreatePost(true)}>
+                    <Button onClick={openCreatePostModal}>
                       สร้างโพสต์แรก
                     </Button>
                   </CardContent>
@@ -231,12 +220,12 @@ export const CommunityFeed: React.FC<CommunityFeedProps> = ({
                   </h3>
                   <div className="space-y-3">
                     {groups.slice(0, 3).map((group) => (
-                      <div 
+                      <div
                         key={group.id}
                         className="flex items-center space-x-3 p-2 rounded-lg hover:bg-muted cursor-pointer"
                       >
-                        <OptimizedImage 
-                          src={group.coverImage} 
+                        <OptimizedImage
+                          src={group.coverImage}
                           alt={group.name}
                           className="h-10 w-10 rounded object-cover"
                           width={40}
@@ -251,9 +240,9 @@ export const CommunityFeed: React.FC<CommunityFeedProps> = ({
                       </div>
                     ))}
                   </div>
-                  <Button 
-                    variant="outline" 
-                    size="sm" 
+                  <Button
+                    variant="outline"
+                    size="sm"
                     className="w-full mt-3"
                     onClick={() => setActiveTab('groups')}
                   >
@@ -271,9 +260,9 @@ export const CommunityFeed: React.FC<CommunityFeedProps> = ({
                   </h3>
                   <div className="space-y-2">
                     {['เชียงใหม่', 'แบกเป้', 'เที่ยวคนเดียว', 'สายกิน', 'ประหยัด'].map((tag) => (
-                      <Badge 
+                      <Badge
                         key={tag}
-                        variant="outline" 
+                        variant="outline"
                         className="cursor-pointer hover:bg-muted w-full justify-start"
                         onClick={() => setSearchQuery(tag)}
                       >
@@ -351,7 +340,7 @@ export const CommunityFeed: React.FC<CommunityFeedProps> = ({
             <Card>
               <CardContent className="p-6 space-y-4">
                 <h3 className="font-medium">วิธีการสะสมคะแนน</h3>
-                
+
                 <div className="space-y-3 text-sm">
                   <div className="flex items-center justify-between p-3 bg-blue-50 dark:bg-blue-950/20 rounded-lg">
                     <div className="flex items-center space-x-2">
@@ -360,7 +349,7 @@ export const CommunityFeed: React.FC<CommunityFeedProps> = ({
                     </div>
                     <Badge variant="secondary">50-100 คะแนน</Badge>
                   </div>
-                  
+
                   <div className="flex items-center justify-between p-3 bg-green-50 dark:bg-green-950/20 rounded-lg">
                     <div className="flex items-center space-x-2">
                       <Star className="h-4 w-4 text-green-500" />
@@ -368,7 +357,7 @@ export const CommunityFeed: React.FC<CommunityFeedProps> = ({
                     </div>
                     <Badge variant="secondary">10-25 คะแนน</Badge>
                   </div>
-                  
+
                   <div className="flex items-center justify-between p-3 bg-purple-50 dark:bg-purple-950/20 rounded-lg">
                     <div className="flex items-center space-x-2">
                       <Star className="h-4 w-4 text-purple-500" />
@@ -376,7 +365,7 @@ export const CommunityFeed: React.FC<CommunityFeedProps> = ({
                     </div>
                     <Badge variant="secondary">5 คะแนน</Badge>
                   </div>
-                  
+
                   <div className="flex items-center justify-between p-3 bg-orange-50 dark:bg-orange-950/20 rounded-lg">
                     <div className="flex items-center space-x-2">
                       <Star className="h-4 w-4 text-orange-500" />
@@ -390,14 +379,6 @@ export const CommunityFeed: React.FC<CommunityFeedProps> = ({
           </div>
         </TabsContent>
       </Tabs>
-
-      {/* Create Post Modal */}
-      <CreatePost
-        open={showCreatePost}
-        onOpenChange={setShowCreatePost}
-        onSubmit={createPost}
-        isSubmitting={isCreatingPost}
-      />
     </div>
   );
 };

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,9 +1,10 @@
 import { useState } from "react";
-import { Menu, X, MapPin, Settings } from "lucide-react";
+import { Menu, X, MapPin, Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Link, useLocation } from "react-router-dom";
 import { DarkModeToggle } from "@/components/ui/dark-mode-toggle";
 import EnhancedLanguageToggle from "./EnhancedLanguageToggle";
+import { useUIContext } from "@/shared/contexts/UIContext";
 
 interface HeaderProps {
   currentLanguage: "th" | "en";
@@ -13,6 +14,7 @@ interface HeaderProps {
 const Header = ({ currentLanguage, onLanguageChange }: HeaderProps) => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const location = useLocation();
+  const { openCreatePostModal } = useUIContext();
 
   const menuItems = [
     { label: currentLanguage === "th" ? "หน้าแรก" : "Home", href: "/" },
@@ -30,12 +32,14 @@ const Header = ({ currentLanguage, onLanguageChange }: HeaderProps) => {
     return location.pathname.startsWith(href);
   };
 
+  const isCommunityPage = location.pathname.startsWith('/community');
+
   return (
     <header className="sticky top-0 z-50 w-full glass-effect border-b border-white/20 shadow-lg safe-area-top">
       <div className="container mx-auto px-4 h-16 flex items-center justify-between">
         {/* Enhanced Logo */}
-        <Link 
-          to="/" 
+        <Link
+          to="/"
           className="flex items-center space-x-2 interactive-scale"
           aria-label={currentLanguage === "th" ? "ไปไหนดี - หน้าแรก" : "PaiNaiDee - Home"}
         >
@@ -48,7 +52,7 @@ const Header = ({ currentLanguage, onLanguageChange }: HeaderProps) => {
         </Link>
 
         {/* Enhanced Desktop Navigation */}
-        <nav 
+        <nav
           className="hidden md:flex items-center space-x-6"
           aria-label={currentLanguage === "th" ? "เมนูหลัก" : "Main navigation"}
         >
@@ -67,26 +71,31 @@ const Header = ({ currentLanguage, onLanguageChange }: HeaderProps) => {
           ))}
         </nav>
 
-        {/* Enhanced Language Toggle - Desktop */}
+        {/* Actions - Desktop */}
         <div className="hidden md:flex items-center space-x-3">
+          {isCommunityPage && (
+            <Button onClick={openCreatePostModal}>
+              <Plus className="mr-2 h-4 w-4" />
+              {currentLanguage === "th" ? "โพสต์" : "Post"}
+            </Button>
+          )}
           <EnhancedLanguageToggle
             currentLanguage={currentLanguage}
             onLanguageChange={onLanguageChange}
             variant="dropdown"
             size="sm"
           />
-          
-
-          {/* Dark Mode Toggle */}
           <DarkModeToggle />
         </div>
 
-        {/* Language Toggle & Mobile Menu */}
+        {/* Actions - Mobile */}
         <div className="flex items-center space-x-3 md:hidden">
-          {/* Dark Mode Toggle */}
+          {isCommunityPage && (
+            <Button size="sm" onClick={openCreatePostModal}>
+              <Plus className="h-5 w-5" />
+            </Button>
+          )}
           <DarkModeToggle className="hidden sm:flex" />
-          
-          {/* Mobile Menu Button */}
           <Button
             variant="ghost"
             size="sm"
@@ -120,7 +129,7 @@ const Header = ({ currentLanguage, onLanguageChange }: HeaderProps) => {
                 {item.label}
               </Link>
             ))}
-            
+
             {/* Developer Dashboard Link - Only in development */}
             {import.meta.env.DEV && (
               <Link
@@ -133,7 +142,7 @@ const Header = ({ currentLanguage, onLanguageChange }: HeaderProps) => {
                 🔧 {currentLanguage === "th" ? "แดชบอร์ดนักพัฒนา" : "Developer Dashboard"}
               </Link>
             )}
-            
+
             {/* Enhanced Language Toggle for Mobile */}
             <div className="pt-4 border-t border-border/30">
               <EnhancedLanguageToggle
@@ -147,7 +156,7 @@ const Header = ({ currentLanguage, onLanguageChange }: HeaderProps) => {
                 className="w-full justify-center"
               />
             </div>
-            
+
             {/* Dark Mode Toggle for Mobile */}
             <div className="flex justify-center">
               <DarkModeToggle size="sm" />

--- a/src/shared/contexts/UIContext.tsx
+++ b/src/shared/contexts/UIContext.tsx
@@ -1,0 +1,36 @@
+import React, { createContext, useState, useContext, ReactNode } from 'react';
+
+interface UIContextType {
+  isCreatePostModalOpen: boolean;
+  openCreatePostModal: () => void;
+  closeCreatePostModal: () => void;
+}
+
+const UIContext = createContext<UIContextType | undefined>(undefined);
+
+export const useUIContext = () => {
+  const context = useContext(UIContext);
+  if (!context) {
+    throw new Error('useUIContext must be used within a UIProvider');
+  }
+  return context;
+};
+
+interface UIProviderProps {
+  children: ReactNode;
+}
+
+export const UIProvider: React.FC<UIProviderProps> = ({ children }) => {
+  const [isCreatePostModalOpen, setCreatePostModalOpen] = useState(false);
+
+  const openCreatePostModal = () => setCreatePostModalOpen(true);
+  const closeCreatePostModal = () => setCreatePostModalOpen(false);
+
+  const value = {
+    isCreatePostModalOpen,
+    openCreatePostModal,
+    closeCreatePostModal,
+  };
+
+  return <UIContext.Provider value={value}>{children}</UIContext.Provider>;
+};


### PR DESCRIPTION
This commit introduces a new 'Post' button in the header on the community feed page, allowing users to create new posts conveniently.

Key changes:
- A 'Post' button with a '+' icon has been added to the main header, visible only on the `/community` route.
- Clicking the button opens a 'Create Post' modal.
- A new `UIContext` has been created to manage the state of the modal globally, making it accessible from any component.
- The `App` component now wraps the application in the `UIProvider` and handles the rendering and logic for the `CreatePost` modal.
- The old 'Create Post' button within the `CommunityFeed` page has been removed and its logic refactored to use the new global modal system.