### PR TITLE
feat: Replace 'Book Now' with 'Post Your Experience' button

### DIFF
--- a/src/app/pages/AttractionDetail.tsx
+++ b/src/app/pages/AttractionDetail.tsx
@@ -34,6 +34,7 @@ import Reviews from "@/components/attraction/Reviews";
 import StickyBottomBar from "@/components/attraction/StickyBottomBar";
 import BreadcrumbNavigation from "@/components/common/BreadcrumbNavigation";
 import OptimizedImage from "@/components/common/OptimizedImage";
+import { useUIContext } from "@/shared/contexts/UIContext";
 import { 
   useAttractionDetail, 
   useRefreshAttraction,
@@ -91,6 +92,8 @@ const AttractionDetail = ({
   const [accommodations, setAccommodations] = useState<Accommodation[]>([]);
   const [accommodationLoading, setAccommodationLoading] = useState(false);
   const [accommodationError, setAccommodationError] = useState<string | null>(null);
+
+  const { openCreatePostModal } = useUIContext();
 
   const content = {
     th: {
@@ -199,6 +202,10 @@ const AttractionDetail = ({
     } finally {
       setAccommodationLoading(false);
     }
+  };
+
+  const handlePostExperience = () => {
+    openCreatePostModal();
   };
 
   if (isLoading) {
@@ -547,12 +554,7 @@ const AttractionDetail = ({
           </CardContent>
         </Card>
 
-        {/* Post Experience Button */}
-        <div className="text-center">
-            <Button size="lg" className="w-full sm:w-auto">
-                {currentLanguage === 'th' ? 'โพสต์ประสบการณ์ของคุณ' : 'Post Your Experience'}
-            </Button>
-        </div>
+        {/* Post Experience Button is now in StickyBottomBar */}
       </div>
 
       {/* Modals */}
@@ -581,7 +583,7 @@ const AttractionDetail = ({
       <StickyBottomBar
         isFavorite={isFavorite}
         onToggleFavorite={toggleFavorite}
-        onBook={handleBookingClick}
+        onPostExperience={handlePostExperience}
         onShare={handleShare}
         currentLanguage={currentLanguage}
       />

--- a/src/components/attraction/StickyBottomBar.tsx
+++ b/src/components/attraction/StickyBottomBar.tsx
@@ -1,33 +1,29 @@
 import * as React from 'react';
 import { Button } from '@/components/ui/button';
-import { Hotel, Share2, Heart } from 'lucide-react';
+import { Camera, Share2, Heart } from 'lucide-react';
 
 interface StickyBottomBarProps {
   isFavorite: boolean;
   onToggleFavorite: () => void;
-  onBook: () => void;
+  onPostExperience: () => void;
   onShare: () => void;
-  price?: string;
   currentLanguage: 'th' | 'en';
 }
 
 const content = {
     th: {
-        bookNow: 'จองเลย',
-        pricePerNight: '/คืน',
+        postExperience: 'โพสต์ประสบการณ์ของคุณ',
     },
     en: {
-        bookNow: 'Book Now',
-        pricePerNight: '/night',
+        postExperience: 'Post Your Experience',
     }
 }
 
 const StickyBottomBar: React.FC<StickyBottomBarProps> = ({
   isFavorite,
   onToggleFavorite,
-  onBook,
+  onPostExperience,
   onShare,
-  price,
   currentLanguage
 }) => {
   const t = content[currentLanguage];
@@ -42,9 +38,9 @@ const StickyBottomBar: React.FC<StickyBottomBarProps> = ({
                 <Share2 className="w-5 h-5 text-muted-foreground" />
             </Button>
         </div>
-        <Button onClick={onBook} className="flex-grow">
-            <Hotel className="w-4 h-4 mr-2" />
-            {t.bookNow}
+        <Button onClick={onPostExperience} className="flex-grow">
+            <Camera className="w-4 h-4 mr-2" />
+            {t.postExperience}
         </Button>
       </div>
     </div>


### PR DESCRIPTION
- Replaced the 'Book Now' button with a 'Post Your Experience' button in the `StickyBottomBar` component.
- The new button opens the 'Create Post' modal.
- Removed the old 'Post Your Experience' button from the `AttractionDetail` page to avoid duplication.