### PR TITLE
feat: Centralize API configuration and make it environment-aware

### DIFF
--- a/src/config/api.ts
+++ b/src/config/api.ts
@@ -1,0 +1,7 @@
+// src/config/api.ts
+const API_BASE =
+  import.meta.env.MODE === "development"
+    ? "http://localhost:5000/api"
+    : "https://athipan01-painaidee_backend.hf.space/api";
+
+export default API_BASE;

--- a/src/shared/services/authService.ts
+++ b/src/shared/services/authService.ts
@@ -1,4 +1,5 @@
 // Authentication and Authorization Service
+import API_BASE from '../../config/api';
 import { 
   UserRole, 
   Permission, 
@@ -11,7 +12,7 @@ import { SecurityAction, RiskLevel, type SecurityAuditLog } from '../types/secur
 class AuthService {
   private currentUser: User | null = null;
   private authToken: string | null = null;
-  private apiBaseUrl = import.meta.env.VITE_API_BASE_URL || 'http://localhost:5000/api';
+  private apiBaseUrl = API_BASE;
 
   // Mock users for development - replace with real API calls
   private mockUsers: User[] = [

--- a/src/shared/services/mediaManagementService.ts
+++ b/src/shared/services/mediaManagementService.ts
@@ -1,4 +1,5 @@
 // Media Management Service for handling place media operations
+import API_BASE from '../../config/api';
 import type { MediaItem, MediaUploadData } from '../types/media';
 import { SecurityLevel } from '../types/media';
 
@@ -33,7 +34,7 @@ export interface PlaceCreationResult {
 }
 
 class MediaManagementService {
-  private apiBaseUrl = import.meta.env.VITE_API_BASE_URL || 'http://localhost:5000/api';
+  private apiBaseUrl = API_BASE;
 
   /**
    * Replace media for an existing place

--- a/src/shared/services/queueService.ts
+++ b/src/shared/services/queueService.ts
@@ -1,4 +1,5 @@
 // Queue Management Service for improved sync performance
+import API_BASE from '../../config/api';
 import {
   QueueItem,
   QueueItemData,
@@ -21,7 +22,7 @@ class QueueService {
   private webSocket: WebSocket | null = null;
   private isProcessing = false;
   private performanceMetrics: PerformanceMetrics[] = [];
-  private apiBaseUrl = import.meta.env.VITE_API_BASE_URL || 'http://localhost:5000/api';
+  private apiBaseUrl = API_BASE;
 
   constructor() {
     this.initializeWebSocket();

--- a/src/shared/services/securityService.ts
+++ b/src/shared/services/securityService.ts
@@ -1,4 +1,5 @@
 // Security Service for file encryption and validation
+import API_BASE from '../../config/api';
 import {
   EncryptionConfig,
   EncryptedFile,
@@ -14,7 +15,7 @@ import {
 import { authService } from './authService';
 
 class SecurityService {
-  private apiBaseUrl = import.meta.env.VITE_API_BASE_URL || 'http://localhost:5000/api';
+  private apiBaseUrl = API_BASE;
   private encryptionConfig: EncryptionConfig = {
     algorithm: 'AES-GCM',
     keySize: 256,

--- a/src/shared/services/testingService.ts
+++ b/src/shared/services/testingService.ts
@@ -21,12 +21,13 @@ import {
 import { authService } from './authService';
 import { queueService } from './queueService';
 import { securityService } from './securityService';
+import API_BASE from '../../config/api';
 
 class TestingService {
   private testSuites = new Map<string, TestSuite>();
   private runningTests = new Map<string, AbortController>();
   private testReports: TestReport[] = [];
-  private apiBaseUrl = import.meta.env.VITE_API_BASE_URL || 'http://localhost:5000/api';
+  private apiBaseUrl = API_BASE;
 
   constructor() {
     this.initializeDefaultTestSuites();

--- a/src/shared/services/timelineSyncService.ts
+++ b/src/shared/services/timelineSyncService.ts
@@ -1,3 +1,4 @@
+import API_BASE from '../../config/api';
 // Timeline Sync Service for managing media timeline database synchronization
 export interface TimelineEntry {
   id: string;
@@ -33,7 +34,7 @@ export interface TimelineQueryOptions {
 }
 
 class TimelineSyncService {
-  private apiBaseUrl = import.meta.env.VITE_API_BASE_URL || 'http://localhost:5000/api';
+  private apiBaseUrl = API_BASE;
   private pendingEntries: TimelineEntry[] = [];
   private isAutoSyncEnabled = true;
   private syncInterval: NodeJS.Timeout | null = null;

--- a/src/shared/services/versionControlService.ts
+++ b/src/shared/services/versionControlService.ts
@@ -11,9 +11,10 @@ import {
 } from '../types/version';
 import type { MediaItem } from '../types/media';
 import { authService } from './authService';
+import API_BASE from '../../config/api';
 
 class VersionControlService {
-  private apiBaseUrl = import.meta.env.VITE_API_BASE_URL || 'http://localhost:5000/api';
+  private apiBaseUrl = API_BASE;
   private mediaVersions = new Map<string, MediaVersion[]>();
   private placeVersions = new Map<string, PlaceVersion[]>();
 

--- a/src/shared/utils/dashboardAPI.ts
+++ b/src/shared/utils/dashboardAPI.ts
@@ -43,8 +43,7 @@ interface SystemMetricsResponse {
   stats: SystemStats;
 }
 
-// Base API configuration
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:5000/api';
+import API_BASE_URL from '../../config/api';
 
 // Debug mode detection
 const IS_DEBUG = import.meta.env.VITE_ENABLE_DEBUG === 'true' || import.meta.env.MODE === 'development';

--- a/src/test/dashboardAPI.test.ts
+++ b/src/test/dashboardAPI.test.ts
@@ -1,13 +1,9 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
-// Mock environment variables - MUST be at the top
-// vi.mock('import.meta', () => ({
-//   env: {
-//     VITE_API_BASE_URL: 'http://localhost:5000/api',
-//     VITE_ENABLE_DEBUG: 'false',
-//     MODE: 'test'
-//   }
-// }));
+// Mock the API_BASE constant
+vi.mock('../config/api', () => ({
+  default: 'http://localhost:5000/api',
+}));
 
 import {
   getServiceStatus,
@@ -22,7 +18,7 @@ import {
 const mockFetch = vi.fn();
 global.fetch = mockFetch;
 
-describe.skip('Dashboard API Integration', () => {
+describe('Dashboard API Integration', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     window.localStorage.getItem.mockReturnValue(null);


### PR DESCRIPTION
Creates a new centralized configuration file `src/config/api.ts` to manage the API base URL. This file exports an `API_BASE` constant that automatically switches between the development URL (`http://localhost:5000/api`) and the production URL (`https://athipan01-painaidee_backend.hf.space/api`) based on the `import.meta.env.MODE`.

Refactors all services and utilities that previously had hardcoded local fallbacks for the API URL to use the new centralized configuration. This eliminates inconsistencies and ensures the correct endpoint is used in both development and production environments.

Updates the test suite for `dashboardAPI.ts` to mock the new configuration module, allowing the previously skipped tests to be re-enabled and pass successfully.