### PR TITLE
fix(api): Use correct base URL and remove /api prefix

### DIFF
--- a/src/components/MobileVideoUpload.tsx
+++ b/src/components/MobileVideoUpload.tsx
@@ -418,7 +418,7 @@ const MobileVideoUpload: React.FC<MobileVideoUploadProps> = ({
     try {
       await chunkUploadService.resumeUpload(
         video.file,
-        '/api/upload/chunk' // This would be your actual upload endpoint
+        '/upload/chunk' // The service now handles the base URL
       );
     } catch (error) {
       toast({
@@ -460,7 +460,7 @@ const MobileVideoUpload: React.FC<MobileVideoUploadProps> = ({
         try {
           const fileUrl = await chunkUploadService.uploadFile(
             video.file,
-            '/api/upload/chunk' // This would be your actual upload endpoint
+            '/upload/chunk' // The service now handles the base URL
           );
           return { ...video, uploadUrl: fileUrl };
         } catch (error) {

--- a/src/components/common/APIIntegrationTest.tsx
+++ b/src/components/common/APIIntegrationTest.tsx
@@ -60,7 +60,7 @@ export const APIIntegrationTest: React.FC<APIIntegrationTestProps> = ({ currentL
       });
       setTests([...testResults]);
 
-      const response = await fetch(`${import.meta.env.VITE_API_BASE_URL}/attractions`, {
+      const response = await fetch(`${import.meta.env.VITE_HF_BACKEND_URL}/attractions`, {
         method: 'GET',
         headers: { 'Content-Type': 'application/json' },
       });

--- a/src/shared/services/chunkUploadService.ts
+++ b/src/shared/services/chunkUploadService.ts
@@ -1,3 +1,5 @@
+import API_BASE from '../../config/api';
+
 export interface ChunkUploadOptions {
   chunkSize?: number; // Default 1MB
   maxRetries?: number; // Default 3
@@ -301,7 +303,7 @@ class ChunkUploadService {
     formData.append('fileName', session.fileName);
     formData.append('totalChunks', session.totalChunks.toString());
     
-    const response = await fetch(uploadUrl, {
+    const response = await fetch(`${API_BASE}${uploadUrl}`, {
       method: 'POST',
       body: formData,
       signal
@@ -313,7 +315,7 @@ class ChunkUploadService {
   }
 
   private async completeUpload(uploadUrl: string, session: UploadSession): Promise<string> {
-    const response = await fetch(`${uploadUrl}/complete`, {
+    const response = await fetch(`${API_BASE}${uploadUrl}/complete`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',


### PR DESCRIPTION
The backend API on Hugging Face Spaces uses a direct URL without the `/api` prefix, which caused connection failures from the frontend.

This commit resolves the issue by:
- Updating the `chunkUploadService` to use the centralized `API_BASE` config, ensuring it prepends the correct host to upload requests.
- Modifying the `MobileVideoUpload` component to pass the correct relative path (`/upload/chunk`) to the service.
- Updating the `APIIntegrationTest` component to use the correct environment variable (`VITE_HF_BACKEND_URL`) for its test `fetch` call.