### PR TITLE
fix(api): Ensure API base URL is correctly formatted

### DIFF
--- a/src/config/api.ts
+++ b/src/config/api.ts
@@ -2,6 +2,17 @@
 
 // Use the new Hugging Face backend URL from environment variables.
 // Fallback to the old local URL if it's not set.
-const API_BASE = import.meta.env.VITE_HF_BACKEND_URL || import.meta.env.VITE_API_BASE_URL;
+let apiBaseUrl = import.meta.env.VITE_HF_BACKEND_URL || import.meta.env.VITE_API_BASE_URL;
+
+// Ensure the base URL includes the /api path for consistency,
+// and remove any trailing slashes before appending.
+if (apiBaseUrl) {
+  apiBaseUrl = apiBaseUrl.replace(/\/$/, ''); // Remove trailing slash
+  if (!apiBaseUrl.endsWith('/api')) {
+    apiBaseUrl += '/api';
+  }
+}
+
+const API_BASE = apiBaseUrl;
 
 export default API_BASE;


### PR DESCRIPTION
The application was experiencing a "Network Error" when deployed because the API requests were being sent to an incorrect path. This was caused by an ambiguity in how the base API URL was constructed.

The frontend code expects the base URL (from the `VITE_HF_BACKEND_URL` environment variable) to include the `/api` path segment. If the environment variable was set without this segment, API calls would fail with a network timeout.

This commit makes the URL construction more robust by modifying `src/config/api.ts`. The new logic ensures that the base URL always ends with `/api`, regardless of whether the environment variable includes it. This resolves the network errors and makes the application's configuration less error-prone.