### PR TITLE
fix(api): Correct backend URL to resolve network errors

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -10,5 +10,5 @@ VITE_ENABLE_ANALYTICS=false
 VITE_ENABLE_TESTING_FEATURES=true
 
 # Hugging Face Backend Configuration
-VITE_HF_BACKEND_URL=https://athipan01-painaidee-backend.hf.space/api
+VITE_HF_BACKEND_URL=https://athipan01-painaidee-backend.hf.space
 VITE_HF_API_KEY=your_hf_api_key_here

--- a/src/config/api.ts
+++ b/src/config/api.ts
@@ -4,13 +4,10 @@
 // Fallback to the old local URL if it's not set.
 let apiBaseUrl = import.meta.env.VITE_HF_BACKEND_URL || import.meta.env.VITE_API_BASE_URL;
 
-// Ensure the base URL includes the /api path for consistency,
-// and remove any trailing slashes before appending.
+// The environment variable should contain the full, correct base URL.
+// We just need to remove any trailing slash to avoid double slashes in requests.
 if (apiBaseUrl) {
   apiBaseUrl = apiBaseUrl.replace(/\/$/, ''); // Remove trailing slash
-  if (!apiBaseUrl.endsWith('/api')) {
-    apiBaseUrl += '/api';
-  }
 }
 
 const API_BASE = apiBaseUrl;


### PR DESCRIPTION
The deployed frontend was experiencing "Network Error" alerts because it was attempting to connect to incorrect backend API paths.

The root cause was a logic flaw in `src/config/api.ts` that unconditionally appended an `/api` suffix to the backend's base URL. However, the live backend hosted on Hugging Face serves its routes from the root path (`/`), not from `/api` as was assumed.

This commit removes the flawed suffix-appending logic, making the environment variable the single source of truth for the API base URL. It also updates the example URL in `.env.development` to reflect the correct production backend URL, preventing future confusion during local development.