### PR TITLE
Refactor data fetching to fix 404 and data errors

### DIFF
--- a/src/app/pages/Explore.tsx
+++ b/src/app/pages/Explore.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { ArrowLeft, Search } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useAttractions } from "@/shared/hooks/useAttractionQueries";
-import { APIErrorDisplay } from "@/components/common/APIErrorDisplay";
+import APIErrorDisplay from "@/components/common/APIErrorDisplay";
 import AttractionCard from "@/components/common/AttractionCard";
 import { Skeleton } from "@/components/ui/skeleton";
 
@@ -15,7 +15,18 @@ interface ExploreProps {
 const Explore = ({ currentLanguage, onBack }: ExploreProps) => {
   const navigate = useNavigate();
   const [searchQuery, setSearchQuery] = useState("");
+  const [favorites, setFavorites] = useState<string[]>([]);
   const { data, isLoading, isError, error, refetch } = useAttractions({ search: searchQuery });
+
+  const handleFavoriteToggle = (id: string) => {
+    setFavorites((prev) =>
+      prev.includes(id) ? prev.filter((fav) => fav !== id) : [...prev, id]
+    );
+  };
+
+  const handleCardClick = (id: string) => {
+    navigate(`/attraction/${id}`);
+  };
 
   const content = {
     th: {
@@ -59,7 +70,7 @@ const Explore = ({ currentLanguage, onBack }: ExploreProps) => {
     );
   }
 
-  const attractions = data?.data?.attractions || [];
+  const attractions = data?.attractions || [];
 
   if (attractions.length === 0) {
     const isSearching = searchQuery.length > 0;
@@ -110,8 +121,10 @@ const Explore = ({ currentLanguage, onBack }: ExploreProps) => {
           {attractions.map((attraction) => (
             <AttractionCard
               key={attraction.id}
-              attraction={attraction}
-              onClick={() => navigate(`/attraction/${attraction.id}`)}
+              {...attraction}
+              isFavorite={favorites.includes(attraction.id)}
+              onFavoriteToggle={handleFavoriteToggle}
+              onCardClick={handleCardClick}
               currentLanguage={currentLanguage}
             />
           ))}

--- a/src/app/pages/Index.tsx
+++ b/src/app/pages/Index.tsx
@@ -7,8 +7,8 @@ import AttractionCard from "@/components/common/AttractionCard";
 import BottomNavigation from "@/components/common/BottomNavigation";
 import APIErrorDisplay from "@/components/common/APIErrorDisplay";
 import OptimizedImage from "@/components/common/OptimizedImage";
-import { SearchResult } from "@/shared/utils/searchAPI";
-import { PostSearchResult } from "@/shared/types/posts";
+import { SearchResult as PostSearchResult } from "@/shared/types/posts";
+import { SearchResult } from "@/shared/types/search";
 import { useAttractions } from "@/shared/hooks/useAttractionQueries";
 import { MapPin, Star, ArrowRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -94,99 +94,38 @@ const Index = ({ currentLanguage, onLanguageChange }: IndexProps) => {
   ];
 
   // Try to fetch real data first, fallback to mock data
-  const { 
-    data: apiData, 
-    error: apiError, 
+  const {
+    data: apiData,
+    error: apiError,
     isLoading: apiLoading,
-    refetch: refetchAttractions 
+    refetch: refetchAttractions
   } = useAttractions({
     page: 1,
     limit: 10,
     category: _selectedCategory === "all" ? undefined : _selectedCategory
   });
 
-  // Mock attraction data as fallback
-  const _attractions = [
-    {
-      id: "1",
-      name: "Phi Phi Islands",
-      nameLocal: "หมู่เกาะพีพี",
-      province: currentLanguage === "th" ? "กระบี่" : "Krabi",
-      category: "Beach",
-      rating: 4.8,
-      reviewCount: 2547,
-      image: heroBeachImage,
-      description:
-        currentLanguage === "th"
-          ? "น้ำทะเลใสและหน้าผาหินปูนที่สวยงาม ทำให้ที่นี่เป็นสวรรค์สำหรับผู้ที่ชื่นชอบชายหาดและการดำน้ำดูปะการัง"
-          : "Crystal clear waters and stunning limestone cliffs make this a paradise for beach lovers and snorkeling enthusiasts.",
-      tags: ["Beach", "Snorkeling", "Island", "Photography"],
-    },
-    {
-      id: "2",
-      name: "Wat Phra Kaew",
-      nameLocal: "วัดพระแก้ว",
-      province: currentLanguage === "th" ? "กรุงเทพฯ" : "Bangkok",
-      category: "Culture",
-      rating: 4.9,
-      reviewCount: 5243,
-      image: templeImage,
-      description:
-        currentLanguage === "th"
-          ? "วัดที่ศักดิ์สิทธิ์ที่สุดในประเทศไทย เป็นที่ประดิษฐานของพระแก้วมรกต"
-          : "The most sacred Buddhist temple in Thailand, home to the revered Emerald Buddha statue.",
-      tags: ["Temple", "Culture", "Buddhism", "History"],
-    },
-    {
-      id: "3",
-      name: "Doi Inthanon",
-      nameLocal: "ดอยอินทนนท์",
-      province: currentLanguage === "th" ? "เชียงใหม่" : "Chiang Mai",
-      category: "Nature",
-      rating: 4.7,
-      reviewCount: 1876,
-      image: mountainImage,
-      description:
-        currentLanguage === "th"
-          ? "ยอดเขาที่สูงที่สุดในประเทศไทย ชมวิวภูเขาที่งดงาม น้ำตก และอากาศเย็นสบาย"
-          : "The highest peak in Thailand offering breathtaking mountain views, waterfalls, and cool weather.",
-      tags: ["Mountain", "Nature", "Hiking", "Waterfalls"],
-    },
-    {
-      id: "4",
-      name: "Floating Market",
-      nameLocal: "ตลาดน้ำ",
-      province: currentLanguage === "th" ? "กรุงเทพฯ" : "Bangkok",
-      category: "Food",
-      rating: 4.5,
-      reviewCount: 3156,
-      image: floatingMarketImage,
-      description:
-        currentLanguage === "th"
-          ? "สัมผัสวัฒนธรรมไทยแบบดั้งเดิม ขณะช้อปปิ้งผลไม้สดและอาหารพื้นเมืองจากเรือ"
-          : "Experience traditional Thai culture while shopping for fresh fruits and local delicacies from boats.",
-      tags: ["Food", "Culture", "Traditional", "Market"],
-    },
-  ];
-
-  // Use API data if available, otherwise use mock data
-  const displayAttractions = apiData?.attractions ? apiData.attractions.map(attraction => ({
-    id: attraction.id,
-    name: attraction.name,
-    nameLocal: attraction.nameLocal || attraction.name,
-    province: "",
-    category: attraction.category,
-    rating: attraction.rating,
-    reviewCount: Math.floor(Math.random() * 5000) + 1000, // Mock review count for API data
-    image: attraction.images?.[0] || heroBeachImage,
-    description: `Discover the beauty of ${attraction.name}`,
-    tags: [attraction.category]
-  })) : mockAttractions;
+  // Use API data if available and has content, otherwise use mock data
+  const displayAttractions = (apiData?.attractions && apiData.attractions.length > 0)
+    ? apiData.attractions.map(attraction => ({
+      id: attraction.id,
+      name: attraction.name,
+      nameLocal: attraction.nameLocal || attraction.name,
+      province: attraction.province,
+      category: attraction.category,
+      rating: attraction.rating,
+      reviewCount: attraction.reviewCount,
+      image: attraction.image || heroBeachImage, // Use placeholder if no image
+      description: attraction.description,
+      tags: attraction.tags,
+    }))
+    : mockAttractions;
 
   // Track if we're using mock data
   useEffect(() => {
-    setUsingMockData(!apiData?.attractions && !apiLoading);
-  }, [apiData, apiLoading]);
+    const isApiUnavailable = !apiLoading && (!!apiError || !apiData?.attractions || apiData.attractions.length === 0);
+    setUsingMockData(isApiUnavailable);
+  }, [apiData, apiError, apiLoading]);
 
   const filteredAttractions =
     _selectedCategory === "all"

--- a/src/shared/hooks/useAttractionQueries.ts
+++ b/src/shared/hooks/useAttractionQueries.ts
@@ -63,46 +63,6 @@ export const useAttractions = (filters?: {
   });
 };
 
-// Hook to refresh attraction data (invalidate cache and refetch)
-export const useRefreshAttraction = () => {
-  const queryClient = useQueryClient();
-  
-  return useMutation({
-    mutationFn: async (id?: string) => {
-      // Call API refresh endpoint
-      const result = await attractionAPI.refreshAttractionData(id);
-      
-      if (id) {
-        // Invalidate specific attraction cache
-        await queryClient.invalidateQueries({
-          queryKey: attractionKeys.detail(id)
-        });
-        
-        // Also invalidate lists that might contain this attraction
-        await queryClient.invalidateQueries({
-          queryKey: attractionKeys.lists()
-        });
-      } else {
-        // Invalidate all attraction caches
-        await queryClient.invalidateQueries({
-          queryKey: attractionKeys.all
-        });
-      }
-      
-      return result;
-    },
-    onSuccess: (data) => {
-      // Success handled by component
-    },
-    onError: (error: Error) => {
-      // Error handled by component  
-    },
-    meta: {
-      errorMessage: 'Failed to refresh attraction data'
-    }
-  });
-};
-
 // Hook to manually invalidate and refetch attraction data
 export const useInvalidateAttraction = () => {
   const queryClient = useQueryClient();


### PR DESCRIPTION
This commit addresses the 404 "Not Found" and "Data not found" errors by refactoring the frontend data fetching logic to align with the current backend API.

The primary issue was that the frontend was calling obsolete `/attractions` endpoints, which do not exist on the deployed Hugging Face backend.

Changes:
- Modified `src/services/attraction.service.ts` to use the correct `GET /search` endpoint instead of the old `/attractions` and `/attractions/{id}` endpoints.
- Removed obsolete functions (`refreshAttractionData`, `fetchNearbyAccommodations`) from the service layer.
- Updated the `useAttractions` hook in `src/shared/hooks/useAttractionQueries.ts` to handle the new API response structure.
- Removed the obsolete `useRefreshAttraction` hook.
- Updated the `Index.tsx` and `Explore.tsx` pages to correctly consume the data from the refactored hooks and handle the `SearchResult` type.
- Improved data mapping and fallback logic in the components.