### PR TITLE
feat: Add production environment for frontend

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,3 @@
+# Production Environment Variables
+# This file is loaded during the 'build' process.
+VITE_HF_BACKEND_URL="https://athipan01-painaidee-backend.hf.space/api"


### PR DESCRIPTION
Introduces a `.env.production` file to correctly configure the frontend application for the production environment.

The deployed frontend was failing to connect to the backend API because it was defaulting to a `localhost` URL. This was caused by the absence of a production-specific environment configuration.

This commit adds the `.env.production` file and defines `VITE_HF_BACKEND_URL` within it, pointing to the correct deployed backend API on Hugging Face. This ensures that the production build of the frontend connects to the correct data source.