### PR TITLE
feat: Integrate legacy attractions API with frontend components

### DIFF
--- a/src/components/common/AttractionListTest.tsx
+++ b/src/components/common/AttractionListTest.tsx
@@ -1,18 +1,28 @@
 import React, { useState, useEffect } from 'react';
-import { getAttractions, Attraction } from '../../lib/axios';
+import { getLegacyAttractions } from '@/services/attraction.service';
+import { SearchResult } from '@/shared/types/search';
+import AttractionCard from './AttractionCard'; // Use the existing AttractionCard component
+
+// This is a test component to demonstrate fetching data from the legacy endpoint
+// and rendering it with the existing AttractionCard component.
 
 const AttractionListTest: React.FC = () => {
-  const [attractions, setAttractions] = useState<Attraction[]>([]);
+  // State for attractions, loading status, and errors
+  const [attractions, setAttractions] = useState<SearchResult[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
+
+  // State for language and favorite status (for demonstration purposes)
+  const [currentLanguage, setCurrentLanguage] = useState<'th' | 'en'>('th');
+  const [favorites, setFavorites] = useState<Set<string>>(new Set());
 
   useEffect(() => {
     const fetchAttractions = async () => {
       try {
         setLoading(true);
-        const response = await getAttractions();
-        // The backend seems to return { attractions: [...] }
-        setAttractions(response.attractions);
+        // Call the new service function
+        const attractionsData = await getLegacyAttractions();
+        setAttractions(attractionsData);
         setError(null);
       } catch (err) {
         if (err instanceof Error) {
@@ -29,25 +39,75 @@ const AttractionListTest: React.FC = () => {
     fetchAttractions();
   }, []);
 
+  // Handler for the favorite button toggle
+  const handleFavoriteToggle = (id: string) => {
+    setFavorites(prevFavorites => {
+      const newFavorites = new Set(prevFavorites);
+      if (newFavorites.has(id)) {
+        newFavorites.delete(id);
+      } else {
+        newFavorites.add(id);
+      }
+      return newFavorites;
+    });
+  };
+
+  // Handler for clicking on a card
+  const handleCardClick = (id:string) => {
+    // In a real app, this would navigate to the attraction's detail page
+    console.log(`Card clicked: ${id}. Would navigate to /attraction/${id}`);
+    alert(`Card clicked: ${id}`);
+  };
+
+
   if (loading) {
-    return <div>Loading attractions...</div>;
+    // A more user-friendly loading state
+    return <div className="text-center p-10">Loading attractions...</div>;
   }
 
   if (error) {
-    return <div style={{ color: 'red' }}>Error: {error}</div>;
+    // A more user-friendly error state
+    return <div className="text-center p-10 text-red-500">Error: {error}</div>;
   }
 
   return (
-    <div>
-      <h2>Attractions from HuggingFace Backend</h2>
+    <div className="p-4">
+      <div className="flex justify-between items-center mb-4">
+        <h2 className="text-2xl font-bold">Attractions from HuggingFace Backend</h2>
+        {/* Language toggle button */}
+        <button
+          onClick={() => setCurrentLanguage(lang => (lang === 'th' ? 'en' : 'th'))}
+          className="px-4 py-2 bg-blue-500 text-white rounded"
+        >
+          Switch to {currentLanguage === 'th' ? 'English' : 'Thai'}
+        </button>
+      </div>
+
       {attractions.length === 0 ? (
         <p>No attractions found.</p>
       ) : (
-        <ul>
+        // Use a responsive grid to display the cards
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
           {attractions.map((attraction) => (
-            <li key={attraction.id}>{attraction.name}</li>
+            <AttractionCard
+              key={attraction.id}
+              id={attraction.id}
+              name={attraction.name}
+              nameLocal={attraction.nameLocal}
+              province={attraction.province}
+              category={attraction.category}
+              rating={attraction.rating}
+              reviewCount={attraction.reviewCount}
+              image={attraction.image}
+              description={attraction.description}
+              tags={attraction.tags || []}
+              isFavorite={favorites.has(attraction.id)}
+              currentLanguage={currentLanguage}
+              onFavoriteToggle={handleFavoriteToggle}
+              onCardClick={handleCardClick}
+            />
           ))}
-        </ul>
+        </div>
       )}
     </div>
   );

--- a/src/services/attraction.service.ts
+++ b/src/services/attraction.service.ts
@@ -98,3 +98,37 @@ export const getAttractions = async (options?: {
     throw new Error(`Failed to fetch attractions. ${getApiErrorMessage(error)}`);
   }
 };
+
+// [NEW] Get list of attractions from the legacy HuggingFace endpoint
+// This function also transforms the data to match the AttractionCardProps
+export const getLegacyAttractions = async (): Promise<SearchResult[]> => {
+  const endpoint = `/attractions`;
+  console.log("✅ Calling legacy HuggingFace endpoint for list:", endpoint);
+
+  try {
+    const { data } = await apiClient.get(endpoint);
+
+    if (data.success && data.data.attractions) {
+      // Transform the API data to match the SearchResult/AttractionCardProps type
+      return data.data.attractions.map((item: any): SearchResult => ({
+        id: item.id.toString(),
+        name: item.name,
+        nameLocal: item.name,
+        province: item.province,
+        category: item.category,
+        image: item.image_url || 'https://via.placeholder.com/400x250?text=No+Image',
+        rating: item.average_rating || 0,
+        reviewCount: item.total_reviews || 0,
+        description: item.description || 'No description available.',
+        tags: item.tags || [], // Assuming tags might exist, otherwise empty array
+        location: item.location || { lat: 0, lng: 0 },
+        amenities: [], // Legacy endpoint doesn't provide amenities
+      }));
+    }
+
+    return [];
+  } catch (error) {
+    console.error(`❌ Error fetching legacy attractions from ${endpoint}:`, error);
+    throw new Error(`Failed to fetch legacy attractions. ${getApiErrorMessage(error)}`);
+  }
+};


### PR DESCRIPTION
This change integrates the legacy HuggingFace attractions API endpoint with the existing React component structure.

• Adds a `getLegacyAttractions` function to `src/services/attraction.service.ts`. This function fetches data from the `/api/attractions` endpoint and transforms it into the `SearchResult` format expected by the frontend components. • Refactors `src/components/common/AttractionListTest.tsx` to use the new service function. The component now correctly renders the fetched data using the sophisticated, pre-existing `AttractionCard` component, demonstrating a fully functional data flow.