### PR TITLE
feat: Add search endpoint check to health page

### DIFF
--- a/src/lib/backendVerifier.ts
+++ b/src/lib/backendVerifier.ts
@@ -84,6 +84,69 @@ export const checkBackendHealth = async (): Promise<TestResult> => {
   }
 };
 
+export const checkSearchEndpoint = async (): Promise<TestResult> => {
+  console.log('🚀 Running search endpoint check...');
+  const searchQuery = 'เชียงใหม่';
+  try {
+    const response = await apiClient.get(`/search?q=${searchQuery}`, { timeout: 10000 });
+
+    if (response.data) {
+      console.log('✅ Search Endpoint Successful!', response.data);
+      return {
+        success: true,
+        status: response.status,
+        data: response.data,
+        message: 'Search endpoint is working correctly.',
+      };
+    } else {
+      console.warn('⚠️ Search endpoint returned unexpected data:', response.data);
+      return {
+        success: false,
+        status: response.status,
+        data: response.data,
+        message: `Search endpoint is reachable, but returned an unexpected response: ${JSON.stringify(response.data)}`,
+      };
+    }
+  } catch (error) {
+    const err = error as AxiosError;
+    console.error('❌ Search Endpoint Failed!', err);
+
+    const errorMessage = (err.message || '').toLowerCase();
+    if (err.code === 'ERR_CORS_MISMATCH' || errorMessage.includes('cors')) {
+      return {
+        success: false,
+        status: 'CORS Error',
+        data: null,
+        message: 'CORS Error: The request was blocked. Ensure the backend allows requests from this origin.',
+      };
+    }
+
+    if (err.response) {
+      const { status, data } = err.response;
+      return {
+        success: false,
+        status,
+        data,
+        message: `Search Endpoint Down: Server responded with status ${status}.`,
+      };
+    } else if (err.request) {
+      return {
+        success: false,
+        status: 'Network Error',
+        data: null,
+        message: 'Network Error: Could not connect to the server. The backend might be down or the URL is incorrect.',
+      };
+    } else {
+      return {
+        success: false,
+        status: 'Request Setup Error',
+        data: null,
+        message: `An unexpected error occurred: ${err.message}`,
+      };
+    }
+  }
+};
+
 
 export const testHuggingFaceConnection = async (): Promise<TestResult> => {
   console.log('🚀 Starting Hugging Face backend connection test...');


### PR DESCRIPTION
This commit enhances the backend health check page by adding a new check for the search API endpoint.

- A new function `checkSearchEndpoint` was added to `src/lib/backendVerifier.ts` to test the `/search?q=เชียงใหม่` endpoint, with robust error handling.
- The `HealthCheckPage` at `src/app/pages/HealthCheckPage.tsx` was updated to run both the health check and the new search check in parallel.
- The UI was refactored to use a reusable `ResultCard` component, displaying the status and results of both checks clearly and independently.